### PR TITLE
WIP: Firefox Compatibility

### DIFF
--- a/src/main/resources/static/js/dm/viewer/ProjectViewer.js
+++ b/src/main/resources/static/js/dm/viewer/ProjectViewer.js
@@ -690,7 +690,7 @@ dm.viewer.ProjectViewer.prototype.openViewerForResource = function(resource) {
     container.setViewer(viewer);
 
     if ( clone || !this.projectController.userHasPermissionOverProject(null, null, dm.data.ProjectController.PERMISSIONS.update)) {
-        viewer.makeUneditable();
+        window.setTimeout(viewer.makeUneditable.bind(viewer), 200);
         viewer.loadResourceByUri(resource.uri);
         container.autoResize();
     } else {

--- a/src/main/resources/static/js/dm/viewer/TextEditor.js
+++ b/src/main/resources/static/js/dm/viewer/TextEditor.js
@@ -105,9 +105,9 @@ dm.viewer.TextEditor.prototype.getSanitizedHtml = function () {
  * sets the contents of the editor to the specified string
  * @param {!string} htmlString the html to be written to the editor
  **/
-dm.viewer.TextEditor.prototype.setHtml = function (htmlString) {
+dm.viewer.TextEditor.prototype.setHtml = function (htmlString, noDelayedChange) {
     if (this.field) {
-        this.field.setHtml(false, htmlString, false );
+        this.field.setHtml(false, htmlString, noDelayedChange === true );
     }
 };
 
@@ -119,7 +119,7 @@ dm.viewer.TextEditor.prototype.safeguardStyles = function () {
     if (this.field) {
         var uriParts = this.uri.split(":");
         var uri = uriParts[uriParts.length - 1];
-        var $contents = $(this.editorIframeElement).contents();
+        var $contents = $($.parseHTML(this.field.getCleanContents()));
         $contents.find("style").each(function(index) {
             var styleText = $(this).text();
             var styleCodex = {};
@@ -137,6 +137,8 @@ dm.viewer.TextEditor.prototype.safeguardStyles = function () {
                 $(this).parent().find(selector).removeClass(styleCodex[selector].oldClass).addClass(styleCodex[selector].newClass);
             }
         });
+        var contentString = $('<div>').append($contents.clone()).remove().html();
+        this.setHtml(contentString, true);
     }
 };
 
@@ -291,7 +293,8 @@ dm.viewer.TextEditor.prototype.render = function(div) {
     this.editorIframe = goog.dom.getFrameContentWindow(this.editorIframeElement);
     this.addStylesheetToEditor(this.styleRoot + 'atb/editorframe.css');
 
-    this.addGlobalEventListeners();
+    window.setTimeout(this.addGlobalEventListeners.bind(this), 100);
+    // this.addGlobalEventListeners();
 
     if (this.container) {
         this.container.autoResize();


### PR DESCRIPTION
This PR reflects initial fixes for #175 and #176, but is more intended for now to track progress on Firefox compatibility in general, since this initial fix is flawed and introduces new bugs. These are documented below. http://sandbox.digitalmappa.org/ is current with the state of progress at the time these bugs were reported.

1: text editor cursor position resets on save (status: reproduced, fix identified)
"Basically, in a text file in a sandbox project, you begin typing, and after a few moments, the cursor leaps up to the very beginning of the text file. This happens consistently so far."

2: font from pasted text no longer persists between editing and public modes (status: not fully reproduced, partial fix identified)
"Normally this only happens in default if you don't paste in fonts from somewhere else, and just type in DM's default text font. A quirk of DM is that when you edit text displays as Times 12pt, but when it displays as a public project it displays as Helvetica 14 pt. 
So to work around this in 1.0, we've been setting our text style and size by pasting it from an external source, and then it displays in the same font and size everywhere. So all our current projects are done this way (I've been doing everything in Times 18pt and pasting it in). 
But when I just made a text file this way in the Sandbox (in Times 18 pt), in public mode it displayed in Helvetica (or some sans serif font).
This isn't good, because users sometimes will need specific fonts to display (say, for runic characters, or whatever)."

3: save alert fires after logging out (status: not reproduced, possible fix identified)
"When you log out, now, it looks like it automatically triggers a save error alert - I noticed this happened in both Chrome and Firefox:
![image](https://user-images.githubusercontent.com/2431978/38382432-92821f70-38cf-11e8-8b71-d55a2f699767.png)
It's not automatic when logging out - it only happens sometimes. 
But it also can happen when just going right to the url for the instance, even if you are not logged in. I just went back to Firefox and opened the sandbox fresh, without being logged in. The one public project I have on there automatically opened, but threw a save alert on top of it, which is weird given that I am not even logged in"

4: hyperlinks in text editor on Firefox (status: partially reproduced, no fix identified)
"something is really squirrelly with trying to make external links with the text editor inside Firefox displays of DM. Trying to input urls for hyperlinks doesn't work - when saving them, the URLs don't actually stick. Relatedly, also trying to change the display text of an existing hyperlink also doesn't "stick" after the hyperlink editing window from the text editor is is closed
Note - these problems only seem to be happening in Firefox. I was able to make external hyperlinks as normal when running the sandbox instance in Chrome."

5: highlights unresponsive in editor mode on Firefox (status: not yet investigated)
"In Firefox, active highlights on text strings are buggy. 
I made these two highlights in a text annotation in a new test project in Firefox. They were active when I made them, but then rolling over them later did nothing (no rollover window opening, and I couldn't link to them from other highlights). 
But when I looked at the highlights in a public view of the project, they were active (i.e. rollovers windows opened as normal when I rolled over them)."

6: resource title editing in Firefox (status: reproduced, no fix identified)
Certain expected text editing behaviors have no result when editing a resource title in place by clicking to turn it into an editable field, including: selecting all the text and beginning to type will not replace the text / has no effect; placing the cursor at the end of the text and hitting delete has no effect